### PR TITLE
fix: escape closing tags in HTML export to prevent XSS

### DIFF
--- a/docs/js/export.js
+++ b/docs/js/export.js
@@ -316,8 +316,8 @@ const Export = {
    * Note: User data is JSON-serialized and parsed at runtime, not interpolated into HTML
    */
   generateStandaloneHTML(map) {
-    // JSON.stringify handles escaping for embedding in script tag
-    const jsonData = JSON.stringify(map);
+    // JSON.stringify + escape closing tags to prevent XSS via </script> in user data
+    const jsonData = JSON.stringify(map).replace(/<\//g, '<\\/');
     const escapedName = this.escapeHtml(map.name);
     const escapedSector = this.escapeHtml(Templates.getSector(map.sector).name);
 

--- a/js/export.js
+++ b/js/export.js
@@ -316,8 +316,8 @@ const Export = {
    * Note: User data is JSON-serialized and parsed at runtime, not interpolated into HTML
    */
   generateStandaloneHTML(map) {
-    // JSON.stringify handles escaping for embedding in script tag
-    const jsonData = JSON.stringify(map);
+    // JSON.stringify + escape closing tags to prevent XSS via </script> in user data
+    const jsonData = JSON.stringify(map).replace(/<\//g, '<\\/');
     const escapedName = this.escapeHtml(map.name);
     const escapedSector = this.escapeHtml(Templates.getSector(map.sector).name);
 


### PR DESCRIPTION
## Summary
- Adds `.replace(/<\//g, '<\\/')` after `JSON.stringify(map)` in `generateStandaloneHTML()` to escape closing tags (`</`) in embedded JSON data
- Prevents a stakeholder name containing `</script>` from breaking out of the script block and injecting arbitrary HTML/JS
- Applied to both `docs/js/export.js` and `js/export.js` (line 320 in each)

## Test plan
- [ ] Create a stakeholder with name `</script><img src=x onerror=alert(1)>` and export as standalone HTML
- [ ] Open the exported HTML file and verify no script injection occurs
- [ ] Verify the stakeholder name displays correctly (with the literal text visible)
- [ ] Verify normal exports (no special characters) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)